### PR TITLE
from six.moves import xrange for Python 3

### DIFF
--- a/cloud_tpu/models/inception/inception_v2.py
+++ b/cloud_tpu/models/inception/inception_v2.py
@@ -30,6 +30,8 @@ from tensorflow.contrib.tpu.python.tpu import tpu_config
 from tensorflow.contrib.tpu.python.tpu import tpu_estimator
 from tensorflow.contrib.tpu.python.tpu import tpu_optimizer
 
+from six.moves import xrange
+
 
 tf.flags.DEFINE_string(
     'master', default_value='local',

--- a/cloud_tpu/models/inception/inception_v3.py
+++ b/cloud_tpu/models/inception/inception_v3.py
@@ -31,6 +31,8 @@ from tensorflow.contrib.tpu.python.tpu import tpu_config
 from tensorflow.contrib.tpu.python.tpu import tpu_estimator
 from tensorflow.contrib.tpu.python.tpu import tpu_optimizer
 
+from six.moves import xrange
+
 
 tf.flags.DEFINE_string(
     'master', default_value='local',

--- a/cloud_tpu/models/inception/inception_v3_old.py
+++ b/cloud_tpu/models/inception/inception_v3_old.py
@@ -31,6 +31,8 @@ from tensorflow.contrib.tpu.python.tpu import tpu_config
 from tensorflow.contrib.tpu.python.tpu import tpu_estimator
 from tensorflow.contrib.tpu.python.tpu import tpu_optimizer
 
+from six.moves import xrange
+
 
 tf.flags.DEFINE_float('learning_rate', 0.02, 'Learning rate.')
 tf.flags.DEFINE_float('depth_multiplier', 1.0, 'Depth Multiplier on Inception')


### PR DESCRIPTION
xrange() was removed in Python 3 in favor of range()