### PR TITLE
from six.moves import xrange

### DIFF
--- a/cloud_tpu/models/densenet/densenet_model.py
+++ b/cloud_tpu/models/densenet/densenet_model.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from six.moves import xrange
+from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
 # Learning hyperaparmeters

--- a/cloud_tpu/models/densenet/densenet_model.py
+++ b/cloud_tpu/models/densenet/densenet_model.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from six.moves import xrange
 import tensorflow as tf
 
 # Learning hyperaparmeters


### PR DESCRIPTION
__xrange()__ was removed from Python 3 in favor of __range()__.